### PR TITLE
Fix CDF monotonicity validation errors for numeric questions

### DIFF
--- a/main_with_no_framework.py
+++ b/main_with_no_framework.py
@@ -301,11 +301,11 @@ async def forecast_individual_question(
     print(f"Comment for post {post_id} (question {question_id}):\n{comment}")
 
     if question_type == "numeric" or question_type == "discrete":
-        summary_of_forecast += f"Forecast: {str(forecast)[:200]}...\n"
+        summary_of_forecast += f"Forecast: {str(forecast)[:400]}...\n"
     else:
         summary_of_forecast += f"Forecast: {forecast}\n"
 
-    summary_of_forecast += f"Comment:\n```\n{comment[:200]}...\n```\n\n"
+    summary_of_forecast += f"Comment:\n```\n{comment[:400]}...\n```\n\n"
 
     if submit_prediction == True:
         forecast_payload = create_forecast_payload(forecast, question_type)


### PR DESCRIPTION
- Add ensure_cdf_monotonic() function to smooth large probability jumps
- Detect jumps exceeding Metaculus validation limits (0.58 for numeric questions)
- Redistribute large jumps across multiple CDF points to maintain compliance
- Remove debug print statements from numeric_questions.py
- Increase forecast/comment display length in main_with_no_framework.py

This resolves validation errors like "continuous_cdf must be increasing by no more than 0.59 at every step" by automatically smoothing problematic CDFs while preserving the underlying probability distribution.

🤖 Generated with [Claude Code](https://claude.ai/code)